### PR TITLE
Allow global button list in config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ text:
 You can also globally define default buttons for any textarea on your site by setting the `simplemde.buttons` variable in your config.php.
 
 ```php
-c::set('textarea.buttons', array(
+c::set('simplemde.buttons', array(
   "bold",
   "italic",
   "link",

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ text:
     - link
 ```
 
+You can also globally define default buttons for any textarea on your site by setting the `simplemde.buttons` variable in your config.php.
+
+```php
+c::set('textarea.buttons', array(
+  "bold",
+  "italic",
+  "link",
+  "email"
+));
+```
+
 ### Page link
 
 As of version 1.1.2 this field will automatically hide modules and modules container pages with the title `_modules` from the page list. To include them you can add this to your `config.php`:

--- a/simplemde/simplemde.php
+++ b/simplemde/simplemde.php
@@ -31,6 +31,8 @@ class SimplemdeField extends TextField {
       }
       else {
         $input->data('buttons', $this->buttons);
+      }  else if(is_array(c::get('simplemde.buttons', false))) {
+        $input->data('buttons', c::get('simplemde.buttons'));
       }
     }
 


### PR DESCRIPTION
This replicates the same functionality that's in the enhanced textarea.
It allows the user to globally define default buttons for any simplemde textarea by setting the `simplemde.buttons` variable in config.php.

Example:

```php
c::set('simplemde.buttons', array(
  "bold",
  "italic",
  "link",
  "email"
));