### PR TITLE
Remove .json from custom routes as it triggers different routing logic in kirby

### DIFF
--- a/simplemde.php
+++ b/simplemde.php
@@ -15,7 +15,7 @@
   
   panel()->routes[] = array(
     'pattern' => array(
-      '(:any)/simplemde/index.json',
+      '(:any)/simplemde/search',
     ),
     'action'  => function() {
       $search = site()->search(get("phrase"), array(
@@ -32,7 +32,7 @@
   
   panel()->routes[] = array(
     'pattern' => array(
-      '(:any)/simplemde/translation.json',
+      '(:any)/simplemde/translation',
     ),
     'action'  => function() {
       if (version_compare(panel()->version(), '2.2', '>=')) {

--- a/simplemde/assets/js/editor.js
+++ b/simplemde/assets/js/editor.js
@@ -13,9 +13,9 @@
     	}
     	    	
     	var field = simplemde.closest(".field");
-    	var indexUrl = simplemde.data("json") + '/index.json';
-    	var translationUrl = simplemde.data("json") + '/translation.json';
     	
+    	var searchUrl = simplemde.data("json") + '/search';
+    	var translationUrl = simplemde.data("json") + '/translation';
     	if(field.data('editor')) {
     	  return $(this);
     	}
@@ -164,7 +164,7 @@
     				    				
     				var index = {
     					url: function(phrase) {
-  							return indexUrl + "?phrase=" + phrase;
+  							return searchUrl + "?phrase=" + phrase;
   						},
     					getValue: "title",
           		template: {


### PR DESCRIPTION
Not really sure what's happening here, but removing `.json` from the routes seems to bypass the logic that's preventing these routes from working in Kirby 2.5.12.

Fixes #21